### PR TITLE
Added an offset parameter to the popup view

### DIFF
--- a/CWPopup/UIViewController+CWPopup.h
+++ b/CWPopup/UIViewController+CWPopup.h
@@ -12,6 +12,7 @@
 
 @property (nonatomic, readwrite) UIViewController *popupViewController;
 @property (nonatomic, readwrite) BOOL useBlurForPopup;
+@property (nonatomic, readwrite) CGPoint popupViewOffset;
 
 - (void)presentPopupViewController:(UIViewController *)viewControllerToPresent animated:(BOOL)flag completion:(void (^)(void))completion;
 - (void)dismissPopupViewControllerAnimated:(BOOL)flag completion:(void (^)(void))completion;

--- a/CWPopup/UIViewController+CWPopup.m
+++ b/CWPopup/UIViewController+CWPopup.m
@@ -159,10 +159,11 @@
 NSString const *CWPopupKey = @"CWPopupkey";
 NSString const *CWBlurViewKey = @"CWFadeViewKey";
 NSString const *CWUseBlurForPopup = @"CWUseBlurForPopup";
+NSString const *CWPopupViewOffset = @"CWPopupViewOffset";
 
 @implementation UIViewController (CWPopup)
 
-@dynamic popupViewController, useBlurForPopup;
+@dynamic popupViewController, useBlurForPopup, popupViewOffset;
 
 #pragma mark - blur view methods
 
@@ -332,7 +333,7 @@ NSString const *CWUseBlurForPopup = @"CWUseBlurForPopup";
         x = ([UIScreen mainScreen].bounds.size.height - frame.size.width)/2;
         y = ([UIScreen mainScreen].bounds.size.width - frame.size.height)/2;
     }
-    return CGRectMake(x, y, frame.size.width, frame.size.height);
+    return CGRectMake(x + viewController.popupViewOffset.x, y + viewController.popupViewOffset.y, frame.size.width, frame.size.height);
 }
 
 - (void)screenOrientationChanged {
@@ -386,6 +387,15 @@ NSString const *CWUseBlurForPopup = @"CWUseBlurForPopup";
     NSNumber *result = objc_getAssociatedObject(self, &CWUseBlurForPopup);
     return [result boolValue];
 
+}
+
+- (void)setPopupViewOffset:(CGPoint)popupViewOffset {
+    objc_setAssociatedObject(self, &CWPopupViewOffset, [NSValue valueWithCGPoint:popupViewOffset], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+- (CGPoint)popupViewOffset {
+    NSValue *offset = objc_getAssociatedObject(self, &CWPopupViewOffset);
+    return [offset CGPointValue];
 }
 
 @end


### PR DESCRIPTION
As I described on issue #9.
I decided to examine the code and turns out it was quite simple to implement.
Here's an usage example, modified from the original code example.

``` Objective-c
SamplePopupViewController *samplePopupViewController = [[SamplePopupViewController alloc] initWithNibName:@"SamplePopupViewController" bundle:nil];

// Add the following line to change the offset
[samplePopupViewController setPopupViewOffset:CGPointMake(0, -40)];

[self presentPopupViewController:samplePopupViewController animated:YES completion:^(void) {
    NSLog(@"popup view presented");
}];
```

If no offset is set, nothing will change and the view will be centered on screen.
